### PR TITLE
Fix some typos and add links in intro_to_datalad.ipynb

### DIFF
--- a/notebooks/intro_to_datalad.ipynb
+++ b/notebooks/intro_to_datalad.ipynb
@@ -381,7 +381,7 @@
     "is only easily possible in the units of single commits. So if one saves commits\n",
     "to several unrelated files or changes, they are hard to disentangle if you ever\n",
     "want to revert some of those changes. But if you, for example, provide a path to\n",
-    "the file you want to save you can specify more precisiley what will be saved\n",
+    "the file you want to save you can specify more precisely what will be saved\n",
     "together:"
    ]
   },
@@ -673,7 +673,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "here is the crucial and incredibly\n",
+    "Here is the crucial and incredibly\n",
     "handy feature of DataLad datasets: at this point, after cloning, the dataset\n",
     "has small files, for example the `README`, but larger files in it don't have any\n",
     "file content yet. It only retrieved what we, in a simplified way, call **file\n",
@@ -1060,7 +1060,7 @@
    "metadata": {},
    "source": [
     "One of the validation\n",
-    "data subdatasets came form another lab that shared their data. After I was\n",
+    "data subdatasets came from another lab that shared their data. After I was\n",
     "almost finished with my paper, I found another paper that reported a mistake in\n",
     "this data. The mistake was still present in the data I was using, though. So by\n",
     "inspecting the history of this dataset you can see that at one point, I\n",
@@ -1091,7 +1091,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But because I can link subdatasets in precise version, I can\n",
+    "But because I can link to precise versions of subdatasets, I can\n",
     "consciously decide and openly record which version of the data I am using or\n",
     "even test how much my results change by resetting the subdataset to an earlier\n",
     "state or updating the dataset to a more recent version."
@@ -1171,8 +1171,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Read up more about the YODA principles and the `yoda` configuration in the `yoda`\n",
-    "section.\n",
+    "Read up more about the YODA principles and the `yoda` configuration in the \n",
+    "[`yoda` section of the DataLad Handbook](https://handbook.datalad.org/en/latest/basics/101-127-yoda.html).\n",
     "\n",
     "Next, install input data as a subdataset. For this, I created a\n",
     "dataset with the `Iris` data and published it on GitHub. Here, we're installing\n",
@@ -1196,7 +1196,7 @@
    "source": [
     "The last piece is the code to run on the data and produce results. For this, here is a\n",
     "k-means classification analysis script written in Python. You can find this analysis\n",
-    "in more detail in the `yoda_project` section:"
+    "in more detail in the [`yoda_project` section of the DataLad Handbook](https://handbook.datalad.org/en/latest/basics/101-130-yodaproject.html):"
    ]
   },
   {


### PR DESCRIPTION
While I was going through this tutorial (linked to from https://www.datalad.org/), I found a few typos and references to sections that did not exist. I fixed the typos and added links to the DataLad Handbook for the referenced sections.

Thanks for this tutorial notebook!